### PR TITLE
[semver:patch] Ensure `continue` job checks out the repository

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -12,6 +12,7 @@ parameters:
     description: "The parameters used for the pipeline. This can either be a JSON object containing parameters or a path to a file containing a JSON object with parameters"
     default: "{}"
 steps:
+  - checkout
   - continue:
       configuration_path: << parameters.configuration_path >>
       parameters: << parameters.parameters >>


### PR DESCRIPTION
### Checklist

- [n/a] All new jobs, commands, executors, parameters have descriptions
- [n/a] Examples have been added for any significant new features
- [n/a] README has been updated, if necessary

### Motivation, issues

Currently the `continue` job doesn't check out the repository, so regardless of the file passed via the `configuration_path` parameter, the job will fail with:

```
jq: error: Could not open file <path_to_file/filename>: No such file or directory
```

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Add a `checkout` step to the job before calling the orb's `continue` command