### PR TITLE
[semver:minor] Parameterise continuation endpoint domain

### DIFF
--- a/src/commands/continue.yml
+++ b/src/commands/continue.yml
@@ -10,10 +10,15 @@ parameters:
     type: string
     description: "The parameters used for the pipeline. This can either be a JSON object containing parameters or a path to a file containing a JSON object with parameters"
     default: "{}"
+  circleci_domain:
+    type: string
+    description: "The domain of the CircleCI installation - defaults to circleci.com. (Only necessary for CircleCI Server users)"
+    default: "circleci.com"
 steps:
   - run:
       environment:
         CONFIG_PATH: <<parameters.configuration_path>>
         PARAMETERS: <<parameters.parameters>>
+        CIRCLECI_DOMAIN: <<parameters.circleci_domain>>
       name: Continue Pipeline
       command: <<include(scripts/continue.sh)>>

--- a/src/commands/finish.yml
+++ b/src/commands/finish.yml
@@ -3,7 +3,15 @@ description: >
   with an empty config to advance the pipeline, but not execute any
   further workflows, preventing other continuations.
 
+parameters:
+  circleci_domain:
+    type: string
+    description: "The domain of the CircleCI installation - defaults to circleci.com. (Only necessary for CircleCI Server users)"
+    default: "circleci.com"
+
 steps:
   - run:
       name: Finish Pipeline
+      environment:
+        CIRCLECI_DOMAIN: <<parameters.circleci_domain>>
       command: <<include(scripts/finish.sh)>>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -11,8 +11,14 @@ parameters:
     type: string
     description: "The parameters used for the pipeline. This can either be a JSON object containing parameters or a path to a file containing a JSON object with parameters"
     default: "{}"
+  circleci_domain:
+    type: string
+    description: "The domain of the CircleCI installation - defaults to circleci.com. (Only necessary for CircleCI Server users)"
+    default: "circleci.com"
+
 steps:
   - checkout
   - continue:
       configuration_path: << parameters.configuration_path >>
       parameters: << parameters.parameters >>
+      circleci_domain: << parameters.circleci_domain >>

--- a/src/scripts/continue.sh
+++ b/src/scripts/continue.sh
@@ -46,5 +46,5 @@ cat /tmp/circleci/continue_post.json
         -H "Content-Type: application/json" \
         -H "Accept: application/json"  \
         --data @/tmp/circleci/continue_post.json \
-        "https://circleci.com/api/v2/pipeline/continue") \
+        "https://${CIRCLECI_DOMAIN}/api/v2/pipeline/continue") \
    -eq 200 ]]

--- a/src/scripts/finish.sh
+++ b/src/scripts/finish.sh
@@ -21,5 +21,5 @@ echo "$JSON_BODY"
         -H "Content-Type: application/json" \
         -H "Accept: application/json"  \
         --data "${JSON_BODY}" \
-        "https://circleci.com/api/v2/pipeline/continue") \
+        "https://${CIRCLECI_DOMAIN}/api/v2/pipeline/continue") \
    -eq 200 ]]


### PR DESCRIPTION
Server customers need to parameterise the continuation endpoint with
their own domain in order to use the continuation orb.