### PR TITLE
[semver:minor] Optional checkout step

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -19,6 +19,10 @@ parameters:
     type: boolean
     description: "Whether to run an optional checkout step before continuing"
     default: true
+  workspace_path:
+    type: string
+    description: "Path to attach the workspace to"
+    default: ""
 
 steps:
   - when:
@@ -26,6 +30,13 @@ steps:
         equal: [ true, << parameters.step_checkout >> ]
       steps:
         - checkout
+  - when:
+      condition:
+        not:
+          equal: [ "", << parameters.workspace_path >> ]
+      steps:
+        - attach_workspace:
+            at: << parameters.workspace_path >>
   - continue:
       configuration_path: << parameters.configuration_path >>
       parameters: << parameters.parameters >>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -15,9 +15,17 @@ parameters:
     type: string
     description: "The domain of the CircleCI installation - defaults to circleci.com. (Only necessary for CircleCI Server users)"
     default: "circleci.com"
+  step_checkout:
+    type: boolean
+    description: "Whether to run an optional checkout step before continuing"
+    default: true
 
 steps:
-  - checkout
+  - when:
+      condition:
+        equal: [ true, << parameters.step_checkout >> ]
+      steps:
+        - checkout
   - continue:
       configuration_path: << parameters.configuration_path >>
       parameters: << parameters.parameters >>

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -1,6 +1,6 @@
 # tests/
 
-This is where your testing scripts for whichever language is embeded in your orb live, which can be executed locally and within a CircleCI pipeline prior to publishing.
+This is where your testing scripts for whichever language is embedded in your orb live, which can be executed locally and within a CircleCI pipeline prior to publishing.
 
 # Testing Orbs
 


### PR DESCRIPTION
- New `step_checkout` boolean parameter, default `true`: skips the `checkout` step is set to `false`
- New `workspace_path` string parameter, default `""`: adds an `attach_workspace` step if set

Closes #28 