### PR TITLE
feat: drive the resource class via a job parameter and default to small

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -3,6 +3,8 @@ description: >
 
 executor: default
 
+resource_class: << parameters.resource_class >>
+
 parameters:
   configuration_path:
     type: string
@@ -23,6 +25,10 @@ parameters:
     type: string
     description: "Path to attach the workspace to"
     default: ""
+  resource_class:
+    type: string
+    description: "Resource class to use"
+    default: "small"
 
 steps:
   - when:


### PR DESCRIPTION
Similar to [this PR](https://github.com/CircleCI-Public/path-filtering-orb/pull/26) for the `path-filtering/filter` job, it would be great to customize the resource class of the `continue` job. 

According to the official documentation, if you do not specify a size, resource_class will be set automatically. In my case, the continuation job runs in the large class and it costs a ton of credit. Therefore, we need to add a resource_class parameter to allow selection of the size of the resource_class for continuation jobs.