### PR TITLE
PIPE-3643 Add checkout and workspace_path parameters

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -15,9 +15,28 @@ parameters:
     type: string
     description: "The domain of the CircleCI installation - defaults to circleci.com. (Only necessary for CircleCI Server users)"
     default: "circleci.com"
+  checkout:
+    type: boolean
+    description: "Whether to run an optional checkout step before continuing"
+    default: true
+  workspace_path:
+    type: string
+    description: "Path to attach the workspace to"
+    default: ""
 
 steps:
-  - checkout
+  - when:
+      condition:
+        equal: [ true, << parameters.checkout >> ]
+      steps:
+        - checkout
+  - when:
+      condition:
+        not:
+          equal: [ "", << parameters.workspace_path >> ]
+      steps:
+        - attach_workspace:
+            at: << parameters.workspace_path >>
   - continue:
       configuration_path: << parameters.configuration_path >>
       parameters: << parameters.parameters >>

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -1,6 +1,6 @@
 # tests/
 
-This is where your testing scripts for whichever language is embeded in your orb live, which can be executed locally and within a CircleCI pipeline prior to publishing.
+This is where your testing scripts for whichever language is embedded in your orb live, which can be executed locally and within a CircleCI pipeline prior to publishing.
 
 # Testing Orbs
 


### PR DESCRIPTION
- Adds new `checkout` boolean parameter, default `true`: skips the `checkout` step when set to `false`
- Adds new `workspace_path` string parameter, default `""`: adds an `attach_workspace` step if set

Closes #28 