### PR TITLE
Feat/recieve files changed

### DIFF
--- a/src/commands/continue.yml
+++ b/src/commands/continue.yml
@@ -19,6 +19,10 @@ parameters:
     description: "Specify when to enable or disable this command"
     enum: ["on_success", "on_fail", "always"]
     default: "on_success"
+  files_changed:
+    type: string
+    default: /tmp/files-changed-list
+    description: When coming from the path-filtering orb, this is the file containing the changed files.
 
 steps:
   - run:
@@ -26,6 +30,7 @@ steps:
         CONFIG_PATH: <<parameters.configuration_path>>
         PARAMETERS: <<parameters.parameters>>
         CIRCLECI_DOMAIN: <<parameters.circleci_domain>>
+        FILES_CHANGED: <<parameters.files_changed>>
       name: Continue Pipeline
       command: <<include(scripts/continue.sh)>>
       when: <<parameters.when>>

--- a/src/commands/continue.yml
+++ b/src/commands/continue.yml
@@ -25,7 +25,7 @@ parameters:
     description: When coming from the path-filtering orb, this is the file containing the changed files.
   parameter_for_files_changed:
     type: string
-    default: "files_changed"
+    default: ""
     description: >
       If you want to get the list of files changed coming from path filtering orb, this is the name for the parameter.
       Defaults to files_changed.

--- a/src/commands/continue.yml
+++ b/src/commands/continue.yml
@@ -23,6 +23,13 @@ parameters:
     type: string
     default: /tmp/files-changed-list
     description: When coming from the path-filtering orb, this is the file containing the changed files.
+  parameter_for_files_changed:
+    type: string
+    default: "files_changed"
+    description: >
+      If you want to get the list of files changed coming from path filtering orb, this is the name for the parameter.
+      Defaults to files_changed.
+      Set to empty string if you don't want the parameter.
 
 steps:
   - run:
@@ -31,6 +38,7 @@ steps:
         PARAMETERS: <<parameters.parameters>>
         CIRCLECI_DOMAIN: <<parameters.circleci_domain>>
         FILES_CHANGED: <<parameters.files_changed>>
+        PARAMETER_FOR_FILES_CHANGED: <<parameters.parameter_for_files_changed>>
       name: Continue Pipeline
       command: <<include(scripts/continue.sh)>>
       when: <<parameters.when>>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -37,6 +37,10 @@ parameters:
     type: executor
     default: default
     description: Executor where this job will run.
+  files_changed:
+    type: string
+    default: /tmp/files-changed-list
+    description: When coming from the path-filtering orb, this is the file containing the changed files.
 
 circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 
@@ -56,4 +60,5 @@ steps:
   - continue:
       configuration_path: << parameters.configuration_path >>
       parameters: << parameters.parameters >>
+      files_changed: << parameters.files_changed >>
       circleci_domain: << parameters.circleci_domain >>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -37,10 +37,6 @@ parameters:
     type: executor
     default: default
     description: Executor where this job will run.
-  files_changed:
-    type: string
-    default: /tmp/files-changed-list
-    description: When coming from the path-filtering orb, this is the file containing the changed files.
 
 circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 
@@ -60,5 +56,4 @@ steps:
   - continue:
       configuration_path: << parameters.configuration_path >>
       parameters: << parameters.parameters >>
-      files_changed: << parameters.files_changed >>
       circleci_domain: << parameters.circleci_domain >>

--- a/src/scripts/continue.sh
+++ b/src/scripts/continue.sh
@@ -30,6 +30,11 @@ if ! $COMMAND; then
     exit 1
 fi
 
+if [ -f "$FILES_CHANGED" ] && [ -s "$FILES_CHANGED" ] && [ -n "$PARAMETER_FOR_FILES_CHANGED" ]; then
+    files_json=$(paste -sd, "$FILES_CHANGED")
+    PARAMS=$(echo "$PARAMS" | jq --argjson files "$files_json" --arg param_name "$PARAMETER_FOR_FILES_CHANGED" '. + {$param_name: $files}')
+fi
+
 mkdir -p /tmp/circleci
 rm -rf /tmp/circleci/continue_post.json
 


### PR DESCRIPTION
Should help with this issue https://github.com/CircleCI-Public/path-filtering-orb/issues/56

This adds a way to send to the dynamic config a new parameter with the files that were changed based on the path filtering orb.
The parameters are only in the command and not in the job as the orb calls the command. When using the job, this logic is ignored as the PARAMETER_FOR_FILES_CHANGED is empty.